### PR TITLE
Remove Simple Networking because it is out of date and archived

### DIFF
--- a/Assets/Networking/bevy_prototype_simple_net.toml
+++ b/Assets/Networking/bevy_prototype_simple_net.toml
@@ -1,3 +1,0 @@
-name = "bevy_prototype_simple_net"
-description = "A working prototype networking plugin that can create client/server systems over TCP or UDP."
-link = "https://github.com/0x22fe/bevy_prototype_simple_net"


### PR DESCRIPTION
I don't think it is useful to have Simple Networking listed as an asset because it is:
1. A prototype
2. Still on Bevy 0.1.3
3. Explicitly archived and not maintained

I am not sure if the same doesn't apply to the laminar bevy plugin but it isn't explicitly archived and has more features.
But I decided 1 PR for Simple Networking makes more sense anyways.