### PR TITLE
add bevy_simple_networking

### DIFF
--- a/Assets/Networking/bevy_simple_networking.toml
+++ b/Assets/Networking/bevy_simple_networking.toml
@@ -1,0 +1,3 @@
+name = "bevy_simple_networking"
+description = "A simple authoritative server networking library for Bevy"
+link = "https://github.com/bacongobbler/bevy_simple_networking"


### PR DESCRIPTION
Hey! I implemented a very simple networking plugin which developers can use to implement dumb client/authoritative server games with Bevy. It's compatible with bevy 0.5.