### PR TITLE
Disambiguate CI Path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@master
 
       - name: "Install Asset Validator"
-        run: cargo install --git https://github.com/bevyengine/bevy-website/ --path generate-assets --bin validate
+        run: cargo install --git https://github.com/bevyengine/bevy-website/ generate-assets --bin validate
 
       - name: "Check Assets"
         run: validate ./

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@master
 
       - name: "Install Asset Validator"
-        run: cargo install --git https://github.com/bevyengine/bevy-website/ --bin validate
+        run: cargo install --git https://github.com/bevyengine/bevy-website/ --path generate-assets --bin validate
 
       - name: "Check Assets"
         run: validate ./


### PR DESCRIPTION
Now that there are multiple cargo projects in the `bevy-website` repo root, `cargo install` needs to select which one to use.
Hopefully fixes the failures encountered in https://github.com/bevyengine/bevy-assets/pull/139