### PR TITLE
Add Shapes category and move bevy_svg into it

### DIFF
--- a/Assets/Shapes/bevy_svg.toml
+++ b/Assets/Shapes/bevy_svg.toml
@@ -1,3 +1,3 @@
 name = "bevy_svg"
-description = "Load and draw SVG-files."
+description = "Load and draw SVG-files in 2D and 3D"
 link = "https://github.com/Weasy666/bevy_svg"


### PR DESCRIPTION
My plugin renders svgs in both, 2D and 3D, so it doesn't fit only in the 2D category. @mockersf suggested on discord, that i create a new category `Shapes` for this purpose, which i have done here.