### PR TITLE
Delete Bevy-Chinese-Website(Bevy中文网).toml

### DIFF
--- a/Learning/Bevy-Chinese-Website(Bevy中文网).toml
+++ b/Learning/Bevy-Chinese-Website(Bevy中文网).toml
@@ -1,3 +1,0 @@
-name = "Bevy Chinese Website(Bevy中文网)"
-description = "Translate official website and The Bevy Book in Chinese"
-link = "https://bevyengine-cn.github.io/"


### PR DESCRIPTION
The content of bevy Chinese website is outdated and misleading. Moreover, this website occupies the first two results in Bing China website search, even surpassing the official website