### PR TITLE
Remove `bevy_canvas`

### DIFF
--- a/Assets/2D/bevy_canvas.toml
+++ b/Assets/2D/bevy_canvas.toml
@@ -1,3 +1,0 @@
-name = "bevy_canvas"
-description = "An immediate mode 2D drawing API."
-link = "https://github.com/Nilirad/bevy_canvas"


### PR DESCRIPTION
Removing `bevy_canvas` as it is severely outdated and I have no intention to update it anymore.

As `bevy_prototype_lyon` gained the ability to dynamically change shapes without trashing and reconstructing entities, `bevy_canvas` became practically irrelevant.