### PR TITLE
Remove kurinji

### DIFF
--- a/Assets/Input/Kurinji.toml
+++ b/Assets/Input/Kurinji.toml
@@ -1,3 +1,0 @@
-name = "Kurinji"
-description = "Input Map for bevy. Converts user input from different input hardware into game specific actions."
-link = "https://crates.io/crates/kurinji"


### PR DESCRIPTION
Kurinji has been [declared EOL](https://github.com/PradeepKumarRajamanickam/kurinji), and the last supported Bevy version is 0.4.