### PR TITLE
Fix bors, for real

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -1,0 +1,5 @@
+status = [
+    "check",
+]
+
+use_squash_merge = true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   pull_request:
+  push:
 
 jobs:
   check:


### PR DESCRIPTION
Enable `bors` bot for the repo.

Fixes the work done by @cart in #224 with @mockersf's suggestion.