### PR TITLE
[Merged by Bors] - remove heron, benimator and impacted

### DIFF
--- a/Assets/Animation/benimator.toml
+++ b/Assets/Animation/benimator.toml
@@ -1,3 +1,0 @@
-name = "benimator"
-description = "Sprite sheet animation"
-link = "https://github.com/jcornaz/benimator"

--- a/Assets/Physics/heron.toml
+++ b/Assets/Physics/heron.toml
@@ -1,3 +1,0 @@
-name = "heron"
-description = "An ergonomic physics API for 2d and 3d bevy games. (powered by rapier)"
-link = "https://github.com/jcornaz/heron"

--- a/Assets/Physics/impacted.toml
+++ b/Assets/Physics/impacted.toml
@@ -1,3 +1,0 @@
-name = "impacted"
-description = "2d collision test for game-development in rust (with optional integration and example for bevy)"
-link = "https://github.com/jcornaz/impacted"


### PR DESCRIPTION
Hi, 

I think it is best to remove all my projects from the bevy assets.

* heron is now discontinued
* benimator is now engine-agnostic
* impacted won't get integration for the next versions of bevy

fix #236