### PR TITLE
[Merged by Bors] - Add iyes crates

### DIFF
--- a/Assets/Helpers/iyes_loopless.toml
+++ b/Assets/Helpers/iyes_loopless.toml
@@ -1,0 +1,3 @@
+name = "iyes_loopless"
+description = "Composable Alternatives to Bevy's RunCriteria, States, and FixedTimestep"
+link = "https://crates.io/crates/iyes_loopless"

--- a/Assets/Helpers/iyes_progress.toml
+++ b/Assets/Helpers/iyes_progress.toml
@@ -1,3 +1,4 @@
-name = "bevy_loading"
+# Formerly bevy_loading
+name = "iyes_progress"
 description = "Easily implement a loading state, tracking the progress of assets and other tasks."
-link = "https://crates.io/crates/bevy_loading"
+link = "https://crates.io/crates/iyes_loopless"

--- a/Assets/Helpers/iyes_scene_tools.toml
+++ b/Assets/Helpers/iyes_scene_tools.toml
@@ -1,0 +1,3 @@
+name = "iyes_scene_tools"
+description = "Helpers for working with Bevy Scenes"
+link = "https://crates.io/crates/iyes_scene_tools"


### PR DESCRIPTION
Adds [`iyes_loopless`](https://crates.io/crates/iyes_loopless), [`iyes_scene_tools`](https://crates.io/crates/iyes_scene_tools), and [`iyes_progress`](https://crates.io/crates/iyes_progress). It also deletes the `bevy_loading` entry, as this crate has been renamed to `iyes_progress`