### PR TITLE
[Merged by Bors] - Add image size limit to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ description = "A short and sweet description of My Cool Plugin"
 # Where can your asset be found. It can be a link to crates.io, github, gitlab or similar.
 link = "https://github.com/me/my_plugin"
 
-# Optional image to showcase your asset. Should be a png/jpg/webp located next to your toml file, less than 2 MB in size.
+# Optional image to showcase your asset.
+# Should be a png/jpg/webp located next to your toml file, less than 2 MB in size.
 image = "my_plugin_icon.png"
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ description = "A short and sweet description of My Cool Plugin"
 # Where can your asset be found. It can be a link to crates.io, github, gitlab or similar.
 link = "https://github.com/me/my_plugin"
 
-# Optional image to showcase your asset. Should be a png/jpg/gif located next to your toml file.
+# Optional image to showcase your asset. Should be a png/jpg/webp located next to your toml file, less than 2 MB in size.
 image = "my_plugin_icon.png"
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ description = "A short and sweet description of My Cool Plugin"
 link = "https://github.com/me/my_plugin"
 
 # Optional image to showcase your asset.
-# Should be a png/jpg/webp located next to your toml file, less than 2 MB in size.
+# Should be a png/jpg/gif/webp located next to your toml file, less than 2 MB in size.
 image = "my_plugin_icon.png"
 ```
 


### PR DESCRIPTION
2 MB or less.

~~Also removes gif from image file type suggestion and replaces it with webp.~~

Also adds webp to the image file type suggestions.