### PR TITLE
Fix `bevy_text_mode` image

### DIFF
--- a/Assets/2D/bevy_text_mode.toml
+++ b/Assets/2D/bevy_text_mode.toml
@@ -1,3 +1,4 @@
 name = "bevy_text_mode"
 description = "A plugin to render 1-bit sprites."
 link = "https://github.com/yopox/bevy_text_mode"
+image = "bevy_text_mode.png"


### PR DESCRIPTION
The `image` property in the toml was missing.