### PR TITLE
Point to asset loader crate instead of workspace

### DIFF
--- a/Assets/Asset Loading/bevy_asset_loader.toml
+++ b/Assets/Asset Loading/bevy_asset_loader.toml
@@ -1,3 +1,3 @@
 name = "bevy_asset_loader"
 description = "Automatically load asset collections during a configurable State"
-link = "https://github.com/NiklasEi/bevy_asset_loader"
+link = "https://github.com/NiklasEi/bevy_asset_loader/tree/main/bevy_asset_loader"


### PR DESCRIPTION
At the moment, `bevy_asset_loader` has no license/Bevy version displayed, because the asset data points to the workspace.