### PR TITLE
Point to bevy_asset_loader on crates.io

### DIFF
--- a/Assets/Asset Loading/bevy_asset_loader.toml
+++ b/Assets/Asset Loading/bevy_asset_loader.toml
@@ -1,3 +1,3 @@
 name = "bevy_asset_loader"
 description = "Automatically load asset collections during a configurable State"
-link = "https://github.com/NiklasEi/bevy_asset_loader/tree/main/bevy_asset_loader"
+link = "https://crates.io/crates/bevy_asset_loader"


### PR DESCRIPTION
To get those licenses and supported Bevy version to show (see #332 for previous attempt)