### PR TITLE
Remove old 0.3 to 0.4 migration guide

### DIFF
--- a/Learning/0.3-to-0.4-(unofficial).toml
+++ b/Learning/0.3-to-0.4-(unofficial).toml
@@ -1,3 +1,0 @@
-name = "0.3 to 0.4 (unofficial)"
-link = "https://sburris.xyz/posts/bevy-update-0-4/"
-description = "Migration guide to 0.4"


### PR DESCRIPTION
Great content, but *extremely* outdated and unhelpful to 99.99% of readers.