### PR TITLE
Changed dungeon quest game to support bevy=0.11

### DIFF
--- a/Apps/Games/dungeon-quest-v2.toml
+++ b/Apps/Games/dungeon-quest-v2.toml
@@ -1,0 +1,7 @@
+name = "Dungeon Quest V2"
+
+description = "Refactored version of Dungeon Quest, for bevy=0.11"
+
+link = "https://github.com/CiderSlime/dungeon-quest"
+
+image = "dungeon-quest.png"


### PR DESCRIPTION
First, I've tried to solve this through PR to original Dungeon Quest, but this repo seems to be abandoned. 
So I had to create this PR, to change game url to newer fork which I can maintain.
https://github.com/CiderSlime/dungeon-quest
Old version was 0.7, which wasn't good for learning purposes.