### PR TITLE
Recommend an image size

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ link = "https://github.com/me/my_plugin"
 
 # Optional image to showcase your asset.
 # Should be a png/jpg/gif/webp located next to your toml file, less than 2 MB in size.
-# We recommend a size of 551x310 pixels. (16:9 aspect ratio)
+# We recommend using a 16:9 aspect ratio with a maximum width of 600 pixels.
 image = "my_plugin_icon.png"
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ link = "https://github.com/me/my_plugin"
 
 # Optional image to showcase your asset.
 # Should be a png/jpg/gif/webp located next to your toml file, less than 2 MB in size.
+# We recommend a size of 551x310 pixels. (16:9 aspect ratio)
 image = "my_plugin_icon.png"
 ```
 


### PR DESCRIPTION
Fixes #188

Just adds a line to the README about dimensions. Would appreciate someone double checking that those are sane dimensions to recommend.

edit: It looks like maybe our responsive code has changed since I determined these values -- When assets are displayed in a single column I am seeing them displayed up to ~551px wide. Maybe something like 551x310 would be more appropriate. (previous values I used were 400x225)