### PR TITLE
Add bevy_simple_screen_boxing

### DIFF
--- a/Assets/Camera/bevy_simple_screen_boxing.toml
+++ b/Assets/Camera/bevy_simple_screen_boxing.toml
@@ -1,0 +1,4 @@
+name = "bevy_simple_screen_boxing"
+description = "A library that provides a simple API for letterboxing/pillarboxing."
+link = "https://crates.io/crates/bevy_simple_screen_boxing"
+crate = "bevy_simple_screen_boxing"


### PR DESCRIPTION
This adds in `bevy_simple_screen_boxing`, although I will admit I'm not sure if the category is correct. I think it might be, but it could also conceivably be put under "Helpers", but I think "Camera" works better.