### PR TITLE
Use more consitent name for `bevy_enhanced_input`

### DIFF
--- a/Assets/Input/bevy_enhanced_input.toml
+++ b/Assets/Input/bevy_enhanced_input.toml
@@ -1,4 +1,4 @@
-name = "Bevy Enhanced Input"
+name = "bevy_enhanced_input"
 description = "Dynamic and contextual input mappings for Bevy, inspired by Unreal Engine Enhanced Input"
 link = "https://crates.io/crates/bevy_enhanced_input"
 crate = "bevy_enhanced_input"


### PR DESCRIPTION
Looks like for crates people usually put the name of the crate.