### PR TITLE
run CI on macos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,8 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    # Run on macos for now to avoid a linux dependency
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@master
 


### PR DESCRIPTION
it seems the dependency in error causing #542  is not pulled on macos