### PR TITLE
Add bevy_web_keepalive

### DIFF
--- a/Assets/Platform Integration/bevy_web_keepalive.toml
+++ b/Assets/Platform Integration/bevy_web_keepalive.toml
@@ -1,0 +1,4 @@
+name = "bevy_web_keepalive"
+description = "Keep Bevy apps running when a browser tab is hidden."
+link = "https://github.com/Nul-led/bevy_web_keepalive"
+crate = "bevy_web_keepalive"


### PR DESCRIPTION
Adds `bevy_web_keepalive` to the Platform Integration category.

This is a Bevy plugin for keeping web builds updating while the browser tab is hidden.

Refs Nul-led/bevy_web_keepalive#9.

Validation:

```text
validate ./
git diff --check
```

`validate ./` completed with the existing metadata warnings for unrelated entries.